### PR TITLE
test: raise coverage to 90%+ with unit and e2e round-trip tests

### DIFF
--- a/tests/e2e/collectors.test.ts
+++ b/tests/e2e/collectors.test.ts
@@ -1,0 +1,148 @@
+import { Client } from 'pg';
+import { PgClient } from '../../src/pg-client';
+import { collectExtensions } from '../../src/pg-objects/extensions';
+import { collectTypes } from '../../src/pg-objects/types';
+import { collectSequences } from '../../src/pg-objects/sequences';
+import { collectTables } from '../../src/pg-objects/tables';
+import { collectIndexes } from '../../src/pg-objects/indexes';
+import { collectViews } from '../../src/pg-objects/views';
+import { collectTriggers } from '../../src/pg-objects/triggers';
+import { collectFunctions } from '../../src/pg-objects/functions';
+
+const COLLECTORS_DB = 'pgsd-collectors';
+
+const host = process.env.TEST_DB_HOST!;
+const port = Number(process.env.TEST_DB_PORT);
+const user = process.env.TEST_DB_USER!;
+const password = process.env.TEST_DB_PASSWORD!;
+
+let raw: Client;
+
+beforeAll(async () => {
+  // Create and populate DB via PgClient.
+  const admin = new PgClient({ host, port, user, password }, { logger: null });
+  await admin.ensureEmptyDb(COLLECTORS_DB);
+
+  await admin.query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
+  await admin.query(`CREATE TYPE mood AS ENUM ('happy', 'sad')`);
+  await admin.query(`CREATE SEQUENCE my_seq INCREMENT 1 MINVALUE 1 MAXVALUE 1000`);
+  await admin.query(
+    `CREATE TABLE parent (id serial primary key, created_at timestamptz default now(), name text not null)`
+  );
+  await admin.query(
+    `CREATE TABLE child (id bigserial primary key, parent_id integer references parent(id), "order" integer)`
+  );
+  await admin.query(`CREATE INDEX idx_child_parent ON child (parent_id)`);
+  await admin.query(`CREATE VIEW parent_names AS SELECT id, name FROM parent`);
+  await admin.query(`CREATE FUNCTION bump_updated() RETURNS trigger AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql`);
+  await admin.query(`CREATE TRIGGER trg_child BEFORE UPDATE ON child FOR EACH ROW EXECUTE FUNCTION bump_updated()`);
+  await admin.end();
+
+  // Open a raw pg.Client connected to the populated DB.
+  raw = new Client({ host, port, user, password, database: COLLECTORS_DB });
+  await raw.connect();
+});
+
+afterAll(async () => {
+  await raw.end();
+
+  const admin = new PgClient({ host, port, user, password }, { logger: null });
+  try {
+    await admin.switchDatabase('postgres');
+    await admin.dropDatabase(COLLECTORS_DB);
+  } catch {
+    // ignore
+  }
+  await admin.end();
+});
+
+test('collectExtensions returns an array (may include pgcrypto)', async () => {
+  const rows = await collectExtensions(raw);
+  expect(Array.isArray(rows)).toBe(true);
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('pgcrypto');
+});
+
+test('collectTypes returns mood enum', async () => {
+  const rows = await collectTypes(raw);
+  const mood = rows.find((r) => r.name === 'mood');
+  expect(mood).toBeDefined();
+  expect(mood!.src.toUpperCase()).toContain('ENUM');
+});
+
+test('collectSequences returns my_seq with CREATE SEQUENCE src', async () => {
+  const rows = await collectSequences(raw);
+  const seq = rows.find((r) => r.name === 'my_seq');
+  expect(seq).toBeDefined();
+  expect(seq!.src.toUpperCase()).toContain('CREATE SEQUENCE');
+});
+
+test('collectTables with skipSchemas:[] returns parent and child with FK reference', async () => {
+  const rows = await collectTables(raw, { skipSchemas: [] });
+  const names = rows.map((r) => r.table);
+  expect(names).toContain('parent');
+  expect(names).toContain('child');
+
+  const child = rows.find((r) => r.table === 'child')!;
+  const hasRef = child.attributes.some((a) => a.references != null);
+  expect(hasRef).toBe(true);
+});
+
+test('collectTables with non-empty skipSchemas still returns parent and child', async () => {
+  const rows = await collectTables(raw, { skipSchemas: ['pg_catalog', 'information_schema'] });
+  const names = rows.map((r) => r.table);
+  expect(names).toContain('parent');
+  expect(names).toContain('child');
+});
+
+test('collectIndexes with skipSchemas:[] contains idx_child_parent with IF NOT EXISTS', async () => {
+  const rows = await collectIndexes(raw, { skipSchemas: [] });
+  const idx = rows.find((r) => r.name === 'idx_child_parent');
+  expect(idx).toBeDefined();
+  expect(idx!.src.toUpperCase()).toContain('IF NOT EXISTS');
+});
+
+test('collectIndexes with non-empty skipSchemas still contains idx_child_parent', async () => {
+  const rows = await collectIndexes(raw, { skipSchemas: ['pg_catalog'] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('idx_child_parent');
+});
+
+test('collectViews with skipSchemas:[] contains parent_names', async () => {
+  const rows = await collectViews(raw, { skipSchemas: [] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('parent_names');
+});
+
+test('collectViews with non-empty skipSchemas still contains parent_names', async () => {
+  const rows = await collectViews(raw, { skipSchemas: ['pg_catalog', 'information_schema'] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('parent_names');
+});
+
+test('collectTriggers with skipSchemas:[] contains trg_child', async () => {
+  const rows = await collectTriggers(raw, { skipSchemas: [] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('trg_child');
+});
+
+test('collectTriggers with non-empty skipSchemas still contains trg_child', async () => {
+  const rows = await collectTriggers(raw, { skipSchemas: ['pg_catalog', 'information_schema'] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('trg_child');
+});
+
+test('collectFunctions with skipSchemas:[] and skipFunctions:[] contains bump_updated', async () => {
+  const rows = await collectFunctions(raw, { skipSchemas: [], skipFunctions: [] });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('bump_updated');
+});
+
+test('collectFunctions with non-empty skipSchemas/skipFunctions contains bump_updated', async () => {
+  const rows = await collectFunctions(raw, {
+    skipSchemas: ['pg_catalog', 'information_schema'],
+    skipFunctions: ['nonexistent_fn'],
+  });
+  const names = rows.map((r) => r.name);
+  expect(names).toContain('bump_updated');
+});

--- a/tests/e2e/collectors.test.ts
+++ b/tests/e2e/collectors.test.ts
@@ -52,8 +52,9 @@ afterAll(async () => {
     await admin.dropDatabase(COLLECTORS_DB);
   } catch {
     // ignore
+  } finally {
+    await admin.end();
   }
-  await admin.end();
 });
 
 test('collectExtensions returns an array (may include pgcrypto)', async () => {

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -2,6 +2,10 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { PgClient } from '../../src/pg-client';
 
+// The tests in this file are intentionally sequential and stateful: each step
+// depends on side effects of the previous one (create → dump → restore → re-dump
+// → truncate). Vitest runs tests within a file in order; do not mark them concurrent.
+
 const SRC_DB = 'pgsd-rt-src';
 const DST_DB = 'pgsd-rt-dst';
 
@@ -55,6 +59,7 @@ test('create source db with rich schema', async () => {
 });
 
 test('dump source db and verify expected file prefixes present', async () => {
+  await client.switchDatabase(SRC_DB);
   await client.dumpSchema({ out: dumpDir1 });
 
   const files = fs.readdirSync(dumpDir1);
@@ -83,6 +88,7 @@ test('restore source dump into destination db', async () => {
 });
 
 test('re-dump destination and verify key objects are present', async () => {
+  await client.switchDatabase(DST_DB);
   await client.dumpSchema({ out: dumpDir2 });
 
   const files1 = fs.readdirSync(dumpDir1).sort();

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { PgClient } from '../../src/pg-client';
+
+const SRC_DB = 'pgsd-rt-src';
+const DST_DB = 'pgsd-rt-dst';
+
+const dumpDir1 = path.resolve(process.cwd(), '__temp__', SRC_DB);
+const dumpDir2 = path.resolve(process.cwd(), '__temp__', DST_DB);
+
+const client = new PgClient(
+  {
+    host: process.env.TEST_DB_HOST,
+    port: Number(process.env.TEST_DB_PORT),
+    user: process.env.TEST_DB_USER,
+    password: process.env.TEST_DB_PASSWORD,
+  },
+  { logger: null }
+);
+
+afterAll(async () => {
+  try {
+    await client.switchDatabase('postgres');
+    await client.dropDatabase(SRC_DB);
+  } catch {
+    // ignore
+  }
+  try {
+    await client.dropDatabase(DST_DB);
+  } catch {
+    // ignore
+  }
+  await client.end();
+  fs.removeSync(dumpDir1);
+  fs.removeSync(dumpDir2);
+});
+
+test('create source db with rich schema', async () => {
+  await client.ensureEmptyDb(SRC_DB);
+
+  // Apply schema objects one at a time to guarantee compatibility.
+  await client.query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
+  await client.query(`CREATE TYPE mood AS ENUM ('happy', 'sad')`);
+  await client.query(`CREATE SEQUENCE my_seq INCREMENT 1 MINVALUE 1 MAXVALUE 1000`);
+  await client.query(
+    `CREATE TABLE parent (id serial primary key, created_at timestamptz default now(), name text not null)`
+  );
+  await client.query(
+    `CREATE TABLE child (id bigserial primary key, parent_id integer references parent(id), "order" integer)`
+  );
+  await client.query(`CREATE INDEX idx_child_parent ON child (parent_id)`);
+  await client.query(`CREATE VIEW parent_names AS SELECT id, name FROM parent`);
+  await client.query(`CREATE FUNCTION bump_updated() RETURNS trigger AS $$ BEGIN RETURN NEW; END; $$ LANGUAGE plpgsql`);
+  await client.query(`CREATE TRIGGER trg_child BEFORE UPDATE ON child FOR EACH ROW EXECUTE FUNCTION bump_updated()`);
+});
+
+test('dump source db and verify expected file prefixes present', async () => {
+  await client.dumpSchema({ out: dumpDir1 });
+
+  const files = fs.readdirSync(dumpDir1);
+
+  const expectedPrefixes = [
+    'table.',
+    'fk.',
+    'function.',
+    'trigger.',
+    'index.',
+    'view.',
+    'sequence.',
+    'type.',
+    'schema.',
+    'extension.',
+  ];
+  for (const prefix of expectedPrefixes) {
+    expect(files.some((f) => f.startsWith(prefix))).toBe(true);
+  }
+});
+
+test('restore source dump into destination db', async () => {
+  await client.switchDatabase('postgres');
+  await client.ensureEmptyDb(DST_DB);
+  await client.restoreSchema({ src: dumpDir1 });
+});
+
+test('re-dump destination and verify key objects are present', async () => {
+  await client.dumpSchema({ out: dumpDir2 });
+
+  const files1 = fs.readdirSync(dumpDir1).sort();
+  const files2 = fs.readdirSync(dumpDir2).sort();
+
+  // Every file from the source dump must appear in the destination dump.
+  // Note: the destination may have extra sequence files because the serial/bigserial
+  // column defaults re-create sequences with auto-suffixed names during restore
+  // (e.g. child_id_seq1). This is a known tool limitation.
+  for (const f of files1) {
+    expect(files2).toContain(f);
+  }
+
+  // Files unaffected by the serial-sequence collision are byte-identical.
+  // Exclude sequence.* (extra files) and table.* (column default references
+  // the renamed sequence) from the strict equality check.
+  const SKIP_PREFIXES = ['sequence.', 'table.'];
+  for (const f of files1.filter((f) => SKIP_PREFIXES.every((p) => !f.startsWith(p)))) {
+    const content1 = fs.readFileSync(path.join(dumpDir1, f), 'utf8');
+    const content2 = fs.readFileSync(path.join(dumpDir2, f), 'utf8');
+    expect(content2).toBe(content1);
+  }
+
+  // Table files must at least exist in the destination.
+  for (const f of files1.filter((f) => f.startsWith('table.'))) {
+    expect(files2).toContain(f);
+  }
+});
+
+test('truncateTables on destination db completes without error', async () => {
+  await client.switchDatabase('postgres');
+  await client.truncateTables(DST_DB);
+});

--- a/tests/unit/fs-schema.test.ts
+++ b/tests/unit/fs-schema.test.ts
@@ -1,0 +1,394 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { vi } from 'vitest';
+import { FsSchema } from '../../src/fs-schema';
+import type { Attribute } from '../../src/pg-objects/tables';
+
+let tmp: string;
+let fsSchema: FsSchema;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pgsd-fs-'));
+  fsSchema = new FsSchema(tmp, null);
+});
+
+afterEach(() => {
+  fs.removeSync(tmp);
+});
+
+// ---------------------------------------------------------------------------
+// clean()
+// ---------------------------------------------------------------------------
+test('clean() empties the directory', () => {
+  fs.outputFileSync(path.join(tmp, 'stray.txt'), 'hello');
+  expect(fs.readdirSync(tmp)).toHaveLength(1);
+  fsSchema.clean();
+  expect(fs.readdirSync(tmp)).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// outputFileSyncSafe collision
+// ---------------------------------------------------------------------------
+test('outputFileSyncSafe collision: creates versioned files and warns', () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const fsSchemaSpy = new FsSchema(tmp, logger);
+
+  const fn = { schema: 'public', name: 'gen_id', src: 'CREATE FUNCTION gen_id() RETURNS uuid AS $$ $$ LANGUAGE sql' };
+  fsSchemaSpy.writeFunction(fn);
+  fsSchemaSpy.writeFunction(fn);
+  fsSchemaSpy.writeFunction(fn);
+
+  expect(fs.existsSync(path.join(tmp, 'function.public.gen_id.sql'))).toBe(true);
+  expect(fs.existsSync(path.join(tmp, 'function.public.gen_id.v2.sql'))).toBe(true);
+  expect(fs.existsSync(path.join(tmp, 'function.public.gen_id.v3.sql'))).toBe(true);
+  expect(logger.warn).toHaveBeenCalledTimes(2);
+});
+
+// ---------------------------------------------------------------------------
+// writeExtension
+// ---------------------------------------------------------------------------
+test('writeExtension produces correct filename and content', () => {
+  const src = 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"';
+  fsSchema.writeExtension({ name: 'uuid-ossp', src });
+  const content = fs.readFileSync(path.join(tmp, 'extension.uuid-ossp.sql'), 'utf8');
+  expect(content).toBe(src);
+});
+
+// ---------------------------------------------------------------------------
+// writeSchema
+// ---------------------------------------------------------------------------
+test('writeSchema wraps in CREATE SCHEMA IF NOT EXISTS', () => {
+  fsSchema.writeSchema({ schema: 'myschema' });
+  const content = fs.readFileSync(path.join(tmp, 'schema.myschema.sql'), 'utf8');
+  expect(content).toBe('CREATE SCHEMA IF NOT EXISTS "myschema"');
+});
+
+// ---------------------------------------------------------------------------
+// writeType
+// ---------------------------------------------------------------------------
+test('writeType normalizes CRLF and writes correct prefix', () => {
+  const src = "CREATE TYPE mood AS ENUM (\r\n  'happy',\r\n  'sad'\r\n)";
+  fsSchema.writeType({ name: 'mood', src });
+  const content = fs.readFileSync(path.join(tmp, 'type.mood.sql'), 'utf8');
+  expect(content).not.toContain('\r');
+  expect(content).toContain('happy');
+});
+
+// ---------------------------------------------------------------------------
+// writeFunction
+// ---------------------------------------------------------------------------
+test('writeFunction produces correct prefix and normalizes src', () => {
+  const src = 'CREATE FUNCTION public.do_thing()\r\nRETURNS void AS $$ $$ LANGUAGE sql';
+  fsSchema.writeFunction({ schema: 'public', name: 'do_thing', src });
+  const content = fs.readFileSync(path.join(tmp, 'function.public.do_thing.sql'), 'utf8');
+  expect(content).not.toContain('\r');
+  expect(content).toContain('do_thing');
+});
+
+// ---------------------------------------------------------------------------
+// writeIndex
+// ---------------------------------------------------------------------------
+test('writeIndex produces correct filename and preserves src', () => {
+  const src = 'CREATE INDEX idx_users_email ON public.users (email)';
+  fsSchema.writeIndex({ schema: 'public', table: 'users', name: 'idx_users_email', src });
+  const content = fs.readFileSync(path.join(tmp, 'index.public.users.idx_users_email.sql'), 'utf8');
+  expect(content).toBe(src);
+});
+
+// ---------------------------------------------------------------------------
+// writeSequence
+// ---------------------------------------------------------------------------
+test('writeSequence produces correct filename and preserves src', () => {
+  const src = 'CREATE SEQUENCE public.users_id_seq START 1';
+  fsSchema.writeSequence({ schema: 'public', name: 'users_id_seq', src });
+  const content = fs.readFileSync(path.join(tmp, 'sequence.public.users_id_seq.sql'), 'utf8');
+  expect(content).toBe(src);
+});
+
+// ---------------------------------------------------------------------------
+// writeView
+// ---------------------------------------------------------------------------
+test('writeView wraps in CREATE OR REPLACE VIEW and uses correct prefix', () => {
+  const src = 'SELECT id, name FROM public.users';
+  fsSchema.writeView({ schema: 'public', name: 'active_users', src });
+  const content = fs.readFileSync(path.join(tmp, 'view.public.active_users.sql'), 'utf8');
+  expect(content).toBe(`CREATE OR REPLACE VIEW public.active_users AS\n${src}\n`);
+});
+
+// ---------------------------------------------------------------------------
+// writeTrigger — unquotes table name in filename
+// ---------------------------------------------------------------------------
+test('writeTrigger uses unquoted table name in filename', () => {
+  const src = 'CREATE TRIGGER trg_audit AFTER INSERT ON "my_table" FOR EACH ROW EXECUTE PROCEDURE audit()';
+  fsSchema.writeTrigger({ schema: 'public', table: '"my_table"', name: 'trg_audit', src });
+  // filename should use unquoted form: trigger.public.my_table.trg_audit.sql
+  expect(fs.existsSync(path.join(tmp, 'trigger.public.my_table.trg_audit.sql'))).toBe(true);
+  const content = fs.readFileSync(path.join(tmp, 'trigger.public.my_table.trg_audit.sql'), 'utf8');
+  expect(content).toBe(`${src}\n`);
+});
+
+// ---------------------------------------------------------------------------
+// attributeSql — serial mapping
+// ---------------------------------------------------------------------------
+test('attributeSql: integer + nextval seq → serial', () => {
+  const result = fsSchema.attributeSql({
+    table: 'users',
+    name: 'id',
+    type: 'integer',
+    defaultValue: "nextval('users_id_seq'::regclass)",
+    description: '',
+    isPrimaryKey: false,
+  });
+  expect(result).toBe('id serial');
+});
+
+test('attributeSql: smallint + nextval seq → smallserial', () => {
+  const result = fsSchema.attributeSql({
+    table: 'users',
+    name: 'count',
+    type: 'smallint',
+    defaultValue: "nextval('users_count_seq'::regclass)",
+    description: '',
+    isPrimaryKey: false,
+  });
+  // "count" is a keyword so it gets quoted
+  expect(result).toBe('"count" smallserial');
+});
+
+test('attributeSql: bigint + nextval seq → bigserial', () => {
+  const result = fsSchema.attributeSql({
+    table: 'events',
+    name: 'event_id',
+    type: 'bigint',
+    defaultValue: "nextval('events_event_id_seq'::regclass)",
+    description: '',
+    isPrimaryKey: false,
+  });
+  expect(result).toBe('event_id bigserial');
+});
+
+test('attributeSql: numeric + nextval seq → throws (no serial mapping)', () => {
+  expect(() =>
+    fsSchema.attributeSql({
+      table: 'users',
+      name: 'amount',
+      type: 'numeric',
+      defaultValue: "nextval('users_amount_seq'::regclass)",
+      description: '',
+      isPrimaryKey: false,
+    })
+  ).toThrow();
+});
+
+// ---------------------------------------------------------------------------
+// attributeSql — references
+// ---------------------------------------------------------------------------
+test('attributeSql: references non-PK → includes column name', () => {
+  const result = fsSchema.attributeSql({
+    table: 'orders',
+    name: 'city_code',
+    type: 'text',
+    defaultValue: null,
+    description: '',
+    isPrimaryKey: false,
+    references: {
+      table: 'cities',
+      attribute: {
+        table: 'cities',
+        name: 'city_id',
+        type: 'integer',
+        defaultValue: null,
+        description: '',
+        isPrimaryKey: false,
+      },
+    },
+  });
+  expect(result).toContain('/* references cities(city_id) */');
+});
+
+test('attributeSql: references PK → no column name', () => {
+  const result = fsSchema.attributeSql({
+    table: 'orders',
+    name: 'user_id',
+    type: 'bigint',
+    defaultValue: null,
+    description: '',
+    isPrimaryKey: false,
+    references: {
+      table: 'cities',
+      attribute: {
+        table: 'cities',
+        name: 'id',
+        type: 'integer',
+        defaultValue: null,
+        description: '',
+        isPrimaryKey: true,
+      },
+    },
+  });
+  expect(result).toContain('/* references cities */');
+  expect(result).not.toContain('(id)');
+});
+
+// ---------------------------------------------------------------------------
+// attributeSql — flags
+// ---------------------------------------------------------------------------
+test('attributeSql: isNotNull → contains "not null"', () => {
+  const result = fsSchema.attributeSql({
+    table: 'users',
+    name: 'email',
+    type: 'text',
+    defaultValue: null,
+    description: '',
+    isPrimaryKey: false,
+    isNotNull: true,
+  });
+  expect(result).toContain('not null');
+});
+
+test('attributeSql: non-serial defaultValue → contains "default"', () => {
+  const result = fsSchema.attributeSql({
+    table: 'stats',
+    name: 'count',
+    type: 'integer',
+    defaultValue: '0',
+    description: '',
+    isPrimaryKey: false,
+  });
+  expect(result).toContain('default 0');
+});
+
+test('attributeSql: isPrimaryKey → contains "primary key"', () => {
+  const result = fsSchema.attributeSql({
+    table: 'users',
+    name: 'id',
+    type: 'uuid',
+    defaultValue: null,
+    description: '',
+    isPrimaryKey: true,
+  });
+  expect(result).toContain('primary key');
+});
+
+test('attributeSql: unsafe name → quoted', () => {
+  const result = fsSchema.attributeSql({
+    table: 'reports',
+    name: 'order',
+    type: 'integer',
+    defaultValue: null,
+    description: '',
+    isPrimaryKey: false,
+  });
+  expect(result.startsWith('"order"')).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// writeTable
+// ---------------------------------------------------------------------------
+test('writeTable: creates table file and fk file', () => {
+  const attributes: Attribute[] = [
+    {
+      table: 'orders',
+      name: 'id',
+      type: 'integer',
+      defaultValue: "nextval('orders_id_seq'::regclass)",
+      description: '',
+      isPrimaryKey: true,
+    },
+    {
+      table: 'orders',
+      name: 'created_at',
+      type: 'timestamp with time zone',
+      defaultValue: null,
+      description: '',
+      isPrimaryKey: false,
+    },
+    {
+      table: 'orders',
+      name: 'city_id',
+      type: 'integer',
+      defaultValue: null,
+      description: '',
+      isPrimaryKey: false,
+      isNotNull: true,
+      references: {
+        table: 'cities',
+        attribute: {
+          table: 'cities',
+          name: 'id',
+          type: 'integer',
+          defaultValue: null,
+          description: '',
+          isPrimaryKey: true,
+        },
+      },
+    },
+    {
+      table: 'orders',
+      name: 'note',
+      type: 'text',
+      defaultValue: null,
+      description: '',
+      isPrimaryKey: false,
+    },
+  ];
+
+  fsSchema.writeTable({ schema: 'public', table: 'orders', attributes });
+
+  // Table file exists and starts correctly
+  const tableContent = fs.readFileSync(path.join(tmp, 'table.public.orders.sql'), 'utf8');
+  expect(tableContent.startsWith('create table public.orders (')).toBe(true);
+
+  // sortedAttributes ordering: id, created_at, city_id (references → higher priority), note
+  const lines = tableContent.split('\n');
+  const colLines = lines.filter((l) => l.startsWith('  '));
+  expect(colLines[0]).toMatch(/id serial/);
+  expect(colLines[1]).toMatch(/created_at/);
+  // city_id has references so it comes before note
+  const cityIdx = colLines.findIndex((l) => l.includes('city_id'));
+  const noteIdx = colLines.findIndex((l) => l.includes('note'));
+  expect(cityIdx).toBeLessThan(noteIdx);
+
+  // FK file exists with double .sql extension (that's how writeTable calls outputFileSyncSafe)
+  const fkFile = path.join(tmp, 'fk.public.orders.city_id_fk.sql.sql');
+  expect(fs.existsSync(fkFile)).toBe(true);
+  const fkContent = fs.readFileSync(fkFile, 'utf8');
+  expect(fkContent).toContain('ALTER TABLE public.orders');
+  expect(fkContent).toContain('ADD CONSTRAINT');
+  expect(fkContent).toContain('FOREIGN KEY');
+  expect(fkContent).toContain('REFERENCES');
+});
+
+// ---------------------------------------------------------------------------
+// readDir — ordering by prefix priority
+// ---------------------------------------------------------------------------
+test('readDir returns files sorted by prefix priority', async () => {
+  fs.outputFileSync(path.join(tmp, 'zzz_unprefixed.sql'), '');
+  fs.outputFileSync(path.join(tmp, 'table.public.a.sql'), '');
+  fs.outputFileSync(path.join(tmp, 'fk.public.a.x_fk.sql'), '');
+  fs.outputFileSync(path.join(tmp, 'schema.public.sql'), '');
+  fs.outputFileSync(path.join(tmp, 'extension.x.sql'), '');
+
+  const files = await fsSchema.readDir();
+
+  const ext = files.findIndex((f) => f === 'extension.x.sql');
+  const sch = files.findIndex((f) => f === 'schema.public.sql');
+  const tbl = files.findIndex((f) => f === 'table.public.a.sql');
+  const fk = files.findIndex((f) => f === 'fk.public.a.x_fk.sql');
+  const zzz = files.findIndex((f) => f === 'zzz_unprefixed.sql');
+
+  expect(ext).toBeLessThan(sch);
+  expect(sch).toBeLessThan(tbl);
+  expect(tbl).toBeLessThan(fk);
+  expect(fk).toBeLessThan(zzz);
+});
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+test('read returns file contents', async () => {
+  fs.outputFileSync(path.join(tmp, 'test.sql'), 'SELECT 1');
+  const content = await fsSchema.read('test.sql');
+  expect(content).toBe('SELECT 1');
+});

--- a/tests/unit/fs-schema.test.ts
+++ b/tests/unit/fs-schema.test.ts
@@ -178,7 +178,7 @@ test('attributeSql: numeric + nextval seq → throws (no serial mapping)', () =>
       description: '',
       isPrimaryKey: false,
     })
-  ).toThrow();
+  ).toThrow(/serial mapping/i);
 });
 
 // ---------------------------------------------------------------------------
@@ -350,7 +350,10 @@ test('writeTable: creates table file and fk file', () => {
   const noteIdx = colLines.findIndex((l) => l.includes('note'));
   expect(cityIdx).toBeLessThan(noteIdx);
 
-  // FK file exists with double .sql extension (that's how writeTable calls outputFileSyncSafe)
+  // FK file exists with a doubled .sql extension. This is a pre-existing quirk in
+  // writeTable (it passes a name already ending in `.sql` to outputFileSyncSafe, which
+  // appends another `.sql`), unlike every other write* method. Asserted as-is to lock in
+  // current behavior; changing the filename is a separate behavior change, out of scope here.
   const fkFile = path.join(tmp, 'fk.public.orders.city_id_fk.sql.sql');
   expect(fs.existsSync(fkFile)).toBe(true);
   const fkContent = fs.readFileSync(fkFile, 'utf8');

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,0 +1,5 @@
+import { PgClient } from '../../src';
+
+test('PgClient is exported as a function/class', () => {
+  expect(typeof PgClient).toBe('function');
+});

--- a/tests/unit/pg-helpers.test.ts
+++ b/tests/unit/pg-helpers.test.ts
@@ -1,4 +1,11 @@
-import { sqlGetFunctionReferences } from '../../src/pg-helpers';
+import {
+  sqlGetFunctionReferences,
+  pgQuoteString,
+  pgQuoteStrings,
+  pgStringArray,
+  all,
+  findAndShiftFunctionReferences,
+} from '../../src/pg-helpers';
 
 const tableSql = `
 create table my.table (
@@ -14,4 +21,67 @@ create table my.table (
 
 test('sqlGetFunctionReferences', () => {
   expect(sqlGetFunctionReferences(tableSql)).toEqual(['uuid_generate_v4']);
+});
+
+// ---------------------------------------------------------------------------
+// pgQuoteString
+// ---------------------------------------------------------------------------
+test('pgQuoteString wraps string in single quotes', () => {
+  expect(pgQuoteString('abc')).toBe("'abc'");
+});
+
+test('pgQuoteString returns non-string values as-is', () => {
+  expect(pgQuoteString(5 as any)).toBe(5 as any);
+});
+
+// ---------------------------------------------------------------------------
+// pgQuoteStrings
+// ---------------------------------------------------------------------------
+test('pgQuoteStrings wraps each element', () => {
+  expect(pgQuoteStrings(['a', 'b'])).toEqual(["'a'", "'b'"]);
+});
+
+// ---------------------------------------------------------------------------
+// pgStringArray
+// ---------------------------------------------------------------------------
+test('pgStringArray parses postgres array literal', () => {
+  expect(pgStringArray('{a,b,c}')).toEqual(['a', 'b', 'c']);
+});
+
+// ---------------------------------------------------------------------------
+// all
+// ---------------------------------------------------------------------------
+test('all maps a function over an array', () => {
+  expect(all((x: number) => x * 2)([1, 2, 3])).toEqual([2, 4, 6]);
+});
+
+// ---------------------------------------------------------------------------
+// findAndShiftFunctionReferences
+// ---------------------------------------------------------------------------
+test('findAndShiftFunctionReferences: shifts matching function file to front', () => {
+  const fNames = ['table.public.t.sql', 'function.public.gen_id.sql'];
+  const fContents = 'create table public.t ( id uuid default gen_id() )';
+  const result = findAndShiftFunctionReferences('table.public.t.sql', fContents, fNames);
+  expect(result).toBe(true);
+  expect(fNames[0]).toBe('function.public.gen_id.sql');
+});
+
+test('findAndShiftFunctionReferences: returns false for non-table file', () => {
+  const fNames = ['function.public.gen_id.sql', 'function.public.other.sql'];
+  const result = findAndShiftFunctionReferences('function.public.gen_id.sql', 'some sql', fNames);
+  expect(result).toBe(false);
+});
+
+test('findAndShiftFunctionReferences: returns false when only builtin refs (now)', () => {
+  const fNames = ['table.public.t.sql', 'function.public.now.sql'];
+  const fContents = 'create table public.t ( created_at timestamp default now() )';
+  const result = findAndShiftFunctionReferences('table.public.t.sql', fContents, fNames);
+  expect(result).toBe(false);
+});
+
+test('findAndShiftFunctionReferences: returns false when referenced function file not in fNames', () => {
+  const fNames = ['table.public.t.sql'];
+  const fContents = 'create table public.t ( id uuid default gen_id() )';
+  const result = findAndShiftFunctionReferences('table.public.t.sql', fContents, fNames);
+  expect(result).toBe(false);
 });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,23 @@
+import { log } from '../../src/utils';
+import { vi } from 'vitest';
+
+test('log.info calls console.info', () => {
+  const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+  log.info('hi');
+  expect(spy).toHaveBeenCalledWith('hi');
+  spy.mockRestore();
+});
+
+test('log.warn calls console.warn', () => {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  log.warn('hi');
+  expect(spy).toHaveBeenCalledWith('hi');
+  spy.mockRestore();
+});
+
+test('log.error calls console.error', () => {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  log.error('hi');
+  expect(spy).toHaveBeenCalledWith('hi');
+  spy.mockRestore();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['**/__tests__/**', '**/tests/**', 'src/bin.ts'],
       reportsDirectory: 'coverage',
+      thresholds: { lines: 90, statements: 90, functions: 90, perFile: false },
     },
     projects: [
       {


### PR DESCRIPTION
## Summary

Raises test coverage from ~52% to **94% statements / 94% lines / 99% functions** (branches 88%). Adds a coverage threshold gate at 90% for lines/statements/functions.

## What changed

**New unit tests (no DB):**
- `tests/unit/fs-schema.test.ts` — `FsSchema` write methods, `attributeSql` (serial mapping, FK reference comments, flag matrix), `writeTable` + FK file generation, `outputFileSyncSafe` collision/versioning, `readDir` ordering, `clean`/`read`.
- `tests/unit/utils.test.ts` — the `log` console shim.
- `tests/unit/index.test.ts` — barrel export.
- `tests/unit/pg-helpers.test.ts` — extended with `pgQuoteString(s)`, `pgStringArray`, `all`, and `findAndShiftFunctionReferences` restore-ordering cases.

**New e2e tests (testcontainers Postgres):**
- `tests/e2e/round-trip.test.ts` — builds a rich schema (extension, enum type, sequence, FK tables, index, view, trigger), dumps it, restores into a fresh DB, re-dumps and asserts determinism, then truncates. Exercises `restoreSchema`, lifecycle helpers, and `findAndShiftFunctionReferences` live.
- `tests/e2e/collectors.test.ts` — calls each `collect*` directly with empty and non-empty `skipSchemas` to cover both branches of the schema-filter ternary.

**Config:**
- `vitest.config.ts` — added `thresholds: { lines: 90, statements: 90, functions: 90, perFile: false }` (branches intentionally ungated).

## Notes
Two pre-existing source quirks were surfaced while writing tests and are documented in the tests rather than fixed (out of scope for this PR):
- `writeTable` emits FK files with a doubled `.sql.sql` extension.
- Serial-backed sequences are double-emitted, so a dump→restore→re-dump is not byte-identical for `table.*`/`sequence.*` files (other object types are).

## Test plan
- `npx vitest run --coverage` — 65 tests pass, thresholds met (Docker required for e2e).
- `npm run eslint` and `npm run build` clean.