### PR TITLE
chore: Dependabot security-only + lockfile refresh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Dependabot configuration — SECURITY UPDATES ONLY, grouped.
+# open-pull-requests-limit: 0 disables routine version-update PRs while
+# leaving Dependabot SECURITY-update PRs enabled. The groups block
+# (applies-to: security-updates) batches security fixes into one PR per
+# ecosystem ("Grouped security updates"). Security updates also require the
+# repo toggle: Settings -> Code security -> Dependabot security updates.
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    groups:
+      security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    groups:
+      security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
Switches all Dependabot ecosystems to security-updates-only.

- `open-pull-requests-limit: 0` set for every ecosystem (disables routine version-update PRs; security-update PRs remain enabled).
- Added a `groups` block (`applies-to: security-updates`) per ecosystem to enable Grouped security updates (one PR per ecosystem for security fixes).

Ecosystems/dirs covered:
- `npm` — `/`
- `github-actions` — `/`

Lockfile refresh: **skipped**. `pnpm update` also rewrote semver ranges in `package.json` (not just `pnpm-lock.yaml`), which is out of scope for this change (manifests must not be edited here), so the lockfile change was reverted and left unchanged.

Dependabot PRs closed (routine, pre-existing): #1–#13 (all 13 open Dependabot PRs).

## Test plan
- [ ] Confirm Dependabot config validates on GitHub (Insights -> Dependency graph -> Dependabot)
- [ ] Enable "Dependabot security updates" toggle in repo settings if not already on