### PR TITLE
chore(deps): drop vulnerable transitive undici, uuid, js-yaml and flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "yargs": "^15.4.1"
   },
   "devDependencies": {
-    "@testcontainers/postgresql": "11.14.0",
+    "@testcontainers/postgresql": "12.1.0",
     "@types/fs-extra": "9.0.1",
     "@types/lodash": "4.14.161",
     "@types/node": "14.6.2",
@@ -66,7 +66,7 @@
     "lefthook": "2.1.6",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "testcontainers": "11.14.0",
+    "testcontainers": "12.1.0",
     "typescript": "4.0.2",
     "vitest": "4.1.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml@>=3.0.0 <3.15.0: 3.15.0
-  undici@>=7.0.0 <7.28.0: 7.28.0
+  js-yaml@>=3.0.0 <3.15.1: 3.15.1
+  flatted@<3.4.2: 3.4.2
   vite@>=8.0.0 <8.0.16: 8.0.16
   brace-expansion@1: 1.1.17
   brace-expansion@2: 2.1.3
@@ -32,8 +32,8 @@ importers:
         version: 15.4.1
     devDependencies:
       '@testcontainers/postgresql':
-        specifier: 11.14.0
-        version: 11.14.0
+        specifier: 12.1.0
+        version: 12.1.0
       '@types/fs-extra':
         specifier: 9.0.1
         version: 9.0.1
@@ -77,8 +77,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       testcontainers:
-        specifier: 11.14.0
-        version: 11.14.0
+        specifier: 12.1.0
+        version: 12.1.0
       typescript:
         specifier: 4.0.2
         version: 4.0.2
@@ -305,8 +305,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@testcontainers/postgresql@11.14.0':
-    resolution: {integrity: sha512-wYbJn8GRTj8qfqzfVubxioYWlHJU/ImIjuzPwyy9C5Qfo6g3GLduPZAj+BifvqTZjgT3gd4gFVLCPhBji7dc1w==}
+  '@testcontainers/postgresql@12.1.0':
+    resolution: {integrity: sha512-Pjf2VSVNirEPfz36nidyrVAnZvc2YhajOznY4VgyEsvfTd5qiMNOuPq96drREvxAUtXl5SFLX7vXj7sSq4aTcA==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -714,9 +714,9 @@ packages:
     resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.12:
-    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
-    engines: {node: '>= 8.0'}
+  dockerode@5.0.1:
+    resolution: {integrity: sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==}
+    engines: {node: '>= 14.17'}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -852,8 +852,8 @@ packages:
     resolution: {integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==}
     engines: {node: '>=4'}
 
-  flatted@2.0.2:
-    resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -881,9 +881,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-port@7.2.0:
-    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
-    engines: {node: '>=16'}
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -985,8 +985,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
   json-schema-traverse@0.4.1:
@@ -1561,8 +1561,9 @@ packages:
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
-  testcontainers@11.14.0:
-    resolution: {integrity: sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==}
+  testcontainers@12.1.0:
+    resolution: {integrity: sha512-YjDLqIITuhGLMnM10yhg3oV6lIG5IMpz1R1DPBZoOOks83q7i7IVpeSWRTiyl7roozjiyLmwIoLK/KY8OnZmIA==}
+    engines: {node: '>= 22.22'}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -1620,9 +1621,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -1633,11 +1634,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   v8-compile-cache@2.4.0:
     resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
@@ -1847,7 +1843,7 @@ snapshots:
       globals: 12.4.0
       ignore: 4.0.6
       import-fresh: 3.3.1
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       lodash: 4.18.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
@@ -1984,9 +1980,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@testcontainers/postgresql@11.14.0':
+  '@testcontainers/postgresql@12.1.0':
     dependencies:
-      testcontainers: 11.14.0
+      testcontainers: 12.1.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -2429,7 +2425,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.12:
+  dockerode@5.0.1:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
@@ -2437,7 +2433,6 @@ snapshots:
       docker-modem: 5.0.7
       protobufjs: 7.6.5
       tar-fs: 2.1.5
-      uuid: 10.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2505,7 +2500,7 @@ snapshots:
       import-fresh: 3.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash: 4.18.1
@@ -2584,11 +2579,11 @@ snapshots:
 
   flat-cache@2.0.1:
     dependencies:
-      flatted: 2.0.2
+      flatted: 3.4.2
       rimraf: 2.6.3
       write: 1.0.3
 
-  flatted@2.0.2: {}
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -2613,7 +2608,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-port@7.2.0: {}
+  get-port@5.1.1: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -2708,7 +2703,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3279,7 +3274,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  testcontainers@11.14.0:
+  testcontainers@12.1.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@types/dockerode': 4.0.1
@@ -3288,14 +3283,14 @@ snapshots:
       byline: 5.0.0
       debug: 4.4.3
       docker-compose: 1.4.2
-      dockerode: 4.0.12
-      get-port: 7.2.0
+      dockerode: 5.0.1
+      get-port: 5.1.1
       proper-lockfile: 4.1.2
       properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.3
       tmp: 0.2.7
-      undici: 7.28.0
+      undici: 8.10.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -3345,7 +3340,7 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@7.28.0: {}
+  undici@8.10.0: {}
 
   universalify@2.0.1: {}
 
@@ -3354,8 +3349,6 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
-
-  uuid@10.0.0: {}
 
   v8-compile-cache@2.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,9 @@ nodeLinker: hoisted
 # Prefer bumping the parent over adding an entry here: an override that forces
 # a version its parent never declared is a standing compatibility risk, and a
 # parent that has already moved on makes the carve-out permanent dead config.
-# The undici and uuid entries lived here until testcontainers 12 arrived with
-# undici ^8.9.0 and dockerode 5 (which dropped uuid outright), retiring both.
+# The undici entry lived here until testcontainers 12 arrived declaring undici
+# ^8.9.0, which retired it. The uuid advisory never needed an entry at all: the
+# same upgrade brought dockerode 5, which dropped its uuid dependency outright.
 overrides:
   # GHSA-52cp-r559-cp3m (HIGH) + GHSA-h67p-54hq-rp68 (MED): js-yaml prototype
   # pollution / unsafe type resolution, both fixed on the 3.x line in 3.15.0.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,14 +4,24 @@ nodeLinker: hoisted
 # development-scope transitive copy whose parent pins it, so a plain in-range
 # refresh cannot reach any of them. Each entry MUST carry a GHSA reference so
 # the carve-out can be dropped once the parent ships the patched version.
+#
+# Prefer bumping the parent over adding an entry here: an override that forces
+# a version its parent never declared is a standing compatibility risk, and a
+# parent that has already moved on makes the carve-out permanent dead config.
+# The undici and uuid entries lived here until testcontainers 12 arrived with
+# undici ^8.9.0 and dockerode 5 (which dropped uuid outright), retiring both.
 overrides:
   # GHSA-52cp-r559-cp3m (HIGH) + GHSA-h67p-54hq-rp68 (MED): js-yaml prototype
   # pollution / unsafe type resolution, both fixed on the 3.x line in 3.15.0.
-  'js-yaml@>=3.0.0 <3.15.0': 3.15.0
-  # GHSA-vxpw-j846-p89q / GHSA-hm92-r4w5-c3mj / GHSA-vmh5-mc38-953g /
-  # GHSA-35p6-xmwp-9g52 / GHSA-g8m3-5g58-fq7m / GHSA-p88m-4jfj-68fv: undici
-  # request-smuggling and redirect/proxy-auth leaks (<7.28.0).
-  'undici@>=7.0.0 <7.28.0': 7.28.0
+  # GHSA-5p4m-2wfm-xmqj (HIGH): quadratic CPU in !!omap resolution — the 5.x
+  # fix was never backported, so the 3.x line needed its own patch in 3.15.1.
+  # Only the 3.x line is installed (via eslint 7), hence no 4.x entry.
+  'js-yaml@>=3.0.0 <3.15.1': 3.15.1
+  # GHSA-rf6f-7fwh-wjgh (HIGH): flatted prototype pollution via parse().
+  # Fixed only on 3.x, so this crosses flat-cache@2.0.1's declared ^2.0.0.
+  # Safe here: flat-cache does a bare require('flatted') and touches only
+  # .parse/.stringify, which flatted 3's exports map still resolves to CJS.
+  'flatted@<3.4.2': 3.4.2
   # GHSA-fx2h-pf6j-xcff (HIGH) + GHSA-v6wh-96g9-6wx3 (MED): vite
   # server.fs.deny bypass on Windows alternate paths + launch-editor NTLMv2
   # hash disclosure (>=8.0.0 <=8.0.15). Transitive via vitest.


### PR DESCRIPTION
## What

Closes all **8 open Dependabot alerts**. Every one was on a **development-scope transitive** dependency — none reach the published `dist/` artifact, which is why this is `chore(deps):` and not a release-triggering `fix:`.

## Where they came from

The alerts traced to exactly two roots:

| Root | Package | Alerts |
|---|---|---|
| `testcontainers@11.14.0` | `undici@7.28.0` | 5 (GHSA-8xcm-r25x-g524, GHSA-4cwx-7wf7-3272, GHSA-jr45-8vmc-qm54, GHSA-v3r7-h72x-cjcm, GHSA-m8rv-5g2x-5cg5) |
| `testcontainers@11.14.0` → `dockerode@4.0.12` | `uuid@10.0.0` | 1 (GHSA-w5hq-g745-h8pq) |
| `eslint@7.8.0` | `js-yaml@3.15.0` | 1 (GHSA-5p4m-2wfm-xmqj) |
| `eslint@7.8.0` → `file-entry-cache` → `flat-cache@2.0.1` | `flatted@2.0.2` | 1 (GHSA-rf6f-7fwh-wjgh) |

## Approach — fix at the root where the parent already moved on

**testcontainers 11.14.0 → 12.1.0** (both `testcontainers` and `@testcontainers/postgresql`). v12 declares `undici: ^8.9.0` and `dockerode: ^5.0.1`, and dockerode 5 **dropped its `uuid` dependency entirely**. That clears 6 of the 8 alerts without adding a single carve-out — and specifically avoids force-bumping `uuid` across `dockerode@4`'s declared `^10.0.0`.

Worth noting the undici advisories also cover the 8.x line (`>= 8.0.0, < 8.9.0`), but `^8.9.0` floors at the patched version. The lockfile resolves `undici@8.10.0`. **The existing `undici` override is therefore retired**, and `uuid` never needs one.

**The other two stay as `overrides`.** They are reachable only through `eslint@7.8.0`, which `eslint-config-pureprofile@3.3.5` pins, so there is no parent to bump:

- `js-yaml` → `3.15.1` — the existing override capped at `3.15.0`, which the new advisory supersedes. 3.15.1 is the 3.x backport of the `!!omap` quadratic-CPU fix (never backported from 5.x).
- `flatted` → `3.4.2` — a forced 2→3 major across `flat-cache@2.0.1`'s declared `^2.0.0`. Verified safe rather than assumed: `flat-cache` does a bare `require('flatted')` (`utils.js:3`) and touches only `.parse`/`.stringify`; it never reaches for the `flatted/cjs` subpath, and flatted 3's `exports` map still resolves `.` → `./cjs/index.js` with those named exports. eslint also only touches this path under `--cache`, which `pnpm eslint` does not pass.

The `pnpm-workspace.yaml` header comment now records the preference for bumping the parent over adding an entry, so the next person hits the cheaper option first.

`vite` and both `brace-expansion` overrides are untouched, as is `allowBuilds` — dockerode 5 still pulls `protobufjs` via `@grpc/*`, and `ssh2`/`cpu-features` still arrive via `ssh-remote-port-forward`.

## Verification

Ran locally on Node 24.16.0 (`.nvmrc` is 24; testcontainers 12 requires `>= 22.22`):

- `pnpm install` — clean, no unused-override warnings
- Lockfile now resolves `undici@8.10.0`, `flatted@3.4.2`, `js-yaml@3.15.1`, `dockerode@5.0.1`, and **no `uuid` at all**
- `pnpm build` — pass
- `pnpm eslint` — pass, 0 errors (2 pre-existing `lines-around-comment` warnings in untouched files). This is the step that would expose a flatted 2→3 interop break.
- `pnpm test:coverage` — **12 files, 111 tests, all passing**, including the e2e dump/restore round-trip booting `postgres:16-alpine` through the upgraded testcontainers client. Coverage 96.91% stmts / 90.98% branches / 97.27% funcs / 96.77% lines, all above the 90% thresholds.

No source or test files needed changes — `tests/vitest.global-setup.ts` uses only the `PostgreSqlContainer` builder API, which is unchanged in v12.

_Generated by [Claude Code](https://claude.ai/code)_
