### PR TITLE
feat: export DumpOmissions and correct stale documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,47 @@ Commit message _format_ is a separate, equally hard requirement, and is covered 
 - `pnpm test` — vitest, both projects (`unit` + `e2e`). `prepublishOnly` runs `build` → `eslint` → `test`.
 - `npm run eslint` — lint `./src` (`--ext=ts,tsx`).
 - `pnpm test:unit` — pure helper tests, no database needed. `pnpm test:e2e` — needs Docker.
+- `pnpm test:coverage` — what CI actually runs. [vitest.config.ts](vitest.config.ts) gates coverage at **90%** lines/statements/functions across `src` as a whole (`perFile: false`, `src/bin.ts` excluded), so a change that adds an untested branch passes `pnpm test` locally and still fails CI. Run this before pushing.
 - Run a single test: `pnpm exec vitest run tests/e2e/dump-db.test.ts` (add `-t "<name>"` to filter).
 - `npm start` — build then run the CLI against `dist/bin.js`.
 
 CLI usage: `pg-schema-dump --url postgres://user:pass@host/db --out ./dir`. Without `--out`, output goes to `pg-schema-dump/<NODE_ENV>/<dbName>`.
+
+## Every change lands through a pull request
+
+Work on a branch and merge through a PR. **Never commit directly to `main`.** This is not merely
+convention: `main` has no branch protection ([docs/release-please.md](docs/release-please.md) §3),
+so a direct push is technically possible — and it bypasses the `PR Title` check, the only thing
+validating the commit subject that release-please parses. The change then lands on `main` and is
+never released.
+
+Two existing rules apply to the branch name, the PR title and the PR body alike:
+
+- **No tracker reference**, anywhere, not even in a footer — see [No tracker references](#no-tracker-references).
+- **The PR title must be a Conventional Commit**, because squash is the only merge method and the
+  title becomes the commit subject verbatim — see [Releases](#releases--conventional-commits-are-mandatory).
+  Pick the type from what the change actually ships: a PR that adds to the public API is a `feat:`
+  even when most of its diff is prose.
+
+### Documentation is part of the change, not a follow-up
+
+Update the documentation a change invalidates **in the same PR**. Two triggers, each of which has
+already produced stale docs here:
+
+- **A change to the public API updates the [README](README.md).** `dumpSchema`'s `DumpOmissions`
+  return shipped in v2.0.0 undocumented, and the type was not even exported — a whole major version
+  where callers could not see or name what the function gave back.
+- **A change to the release process or a workflow updates [docs/release-please.md](docs/release-please.md).**
+  It is declared the source of truth for that topic, so nothing else contradicts it when it drifts;
+  it went two releases still describing the repo as having never cut an automated one.
+
+Also update this file when a change alters the architecture, the commands, or a convention
+described above.
+
+This licence covers hand-written documentation only — `README.md`, `AGENTS.md` and `docs/`. It does
+**not** extend to `CHANGELOG.md`, `package.json`'s `version` or `.release-please-manifest.json`,
+which release-please owns and which must never be hand-edited (see
+[Releases](#releases--conventional-commits-are-mandatory)).
 
 ## Releases — Conventional Commits are mandatory
 
@@ -65,11 +102,21 @@ The `e2e` project (`tests/e2e/`) starts an ephemeral Postgres via Testcontainers
 `TEST_DB_USER` / `TEST_DB_PASSWORD`) to run against an existing instance instead.
 The unit tests (`tests/unit/`) are pure and need no database.
 
+`tests/vitest.global-setup.ts` starts **one** `postgres:16-alpine` container for the whole
+e2e project and exports its coordinates as those same env vars. The project runs
+`pool: 'forks'` with `singleFork: true` and `fileParallelism: false`, so every e2e test
+shares that one instance: a new test must create and drop its own database (`ensureEmptyDb`)
+rather than assuming an isolated server, and must not leave global state behind. The
+container image also bounds what is testable — a feature that needs a newer Postgres needs
+that pin raised first.
+
 ## Architecture
 
 Flow: **collect** (read catalog) → **write** (emit files) — orchestrated by `PgClient.dumpSchema`.
 
-- `src/pg-client.ts` — `PgClient`, the single public export (`src/index.ts` re-exports only this). Holds connection config (parses a URL via `pg-connection-string`, or takes a `pg.ClientConfig`). Key design point: **connections are not kept open** — `query()` does `connect → query → end` each call (see commit `v1.1.0`). `dumpSchema` is the exception: it opens one connection, runs all collectors in a single `Promise.all`, then ends. Also provides DB lifecycle helpers used by tests and consumers (`ensureEmptyDb`, `switchDatabase`, `dropDatabase`, `truncateTables`, `restoreSchema`).
+- `src/index.ts` — the entire public surface: the `PgClient` class and the `DumpOmissions` type it returns. Nothing else is re-exported, so anything a consumer needs to name must be added here deliberately.
+- `src/bin.ts` — the CLI entrypoint (`#!/usr/bin/env node`), and the only place scope arrives from a user. yargs defines `--url` (required), `--out`, `--scope-file` and the repeatable `--include-schema` / `--include-table` / `--include-function`; a manifest read by `loadScopeFile` is combined with those flags by `mergeScope`, the result goes through `validateScope`, and only then is `PgClient` constructed. The `--out` default resolves `current_database()` over a throwaway `pg.Client` first. Excluded from coverage, so logic worth testing belongs in a module it calls rather than here.
+- `src/pg-client.ts` — `PgClient`. Holds connection config (parses a URL via `pg-connection-string`, or takes a `pg.ClientConfig`). Key design point: **connections are not kept open** — `query()` does `connect → query → end` each call (see commit `v1.1.0`). `dumpSchema` is the exception: it opens one connection, runs all collectors in a single `Promise.all`, then ends. It returns a `DumpOmissions` (`{ droppedForeignKeys, excludedViews }`) as well as logging it, because `logger: null` is supported and a scope that silently dropped an FK is the costliest failure to find late — a new kind of omission belongs in that return value, not only in a log line. Also provides DB lifecycle helpers used by tests and consumers (`ensureEmptyDb`, `switchDatabase`, `dropDatabase`, `truncateTables`, `restoreSchema`).
 - `src/pg-objects/*.ts` — one `collect<Object>(client, opts)` per object kind (extensions, types, functions, indexes, sequences, tables, triggers, views, constraints). Each runs a raw `pg_catalog` query and returns plain rows. `tables.ts` builds each column via nested `jsonb_build_object` in SQL. Constraint and index DDL is **not** hand-assembled — `pg_get_constraintdef` / `pg_get_indexdef` produce it. To add/change what's captured, edit the relevant collector's query.
 - `src/pg-objects/scope-sql.ts` — **all shared scope SQL. Nothing here may be restated in a collector.** Two rounds of review found bugs that were exactly a collector hand-rolling its own variant of one of these and getting it subtly wrong, so if a collector needs one of these questions answered, it calls the function:
   - `dependencyOwnerFromSql()` — resolves a `pg_depend` row to the relation whose definition carries the dependency. Each dependent class (`pg_attrdef`, `pg_constraint`, `pg_rewrite`, `pg_trigger`, `pg_index`) keeps its owning relation in a different column, so this is a five-way join that must be identical everywhere. Exposes `dpd`, `dep_owner`, `dep_owner_ns`.
@@ -77,7 +124,7 @@ Flow: **collect** (read catalog) → **write** (emit files) — orchestrated by 
   - `dependencyOwnerInScopeSql(scope)` — the predicate on that resolved owner, including the viable-view branch that breaks the view/function circularity.
   - `viewReadsOnlyInScopeRelationsSql(scope, relOid)` and `DEPENDABLE_RELATION_KINDS` — one definition of "a relation the scope decides", so `views.ts` and the seed cannot disagree about, say, whether a foreign table counts.
   - `inScopeFunctionOidsSql(scope)` — "which functions does this scope reach": the seed above plus the `includeFunctions` escape hatch, then the function-to-function closure. `functions.ts`, `sequences.ts`, `types.ts` and `views.ts` all defer to it.
-- `src/scope.ts` / `src/scope-file.ts` — `ScopeOptions` → `ResolvedScope` (SQL predicates; every one self-parenthesizes). `scope-file.ts` loads and **validates** the JSON manifest, and `validateScope` is applied to CLI flags too, so a malformed `schema.table` entry is an error rather than a silently empty dump.
+- `src/scope.ts` / `src/scope-file.ts` — `ScopeOptions` → `ResolvedScope` (SQL predicates; every one self-parenthesizes). `scope-file.ts` loads and **validates** the JSON manifest (`loadScopeFile`), unions a manifest with CLI flags (`mergeScope`), and checks the result (`validateScope`). `validateScope` runs at all three boundaries — manifest, CLI flags, and the `scope` constructor option — so a malformed `schema.table` entry is an error rather than a silently empty dump.
 - `src/fs-schema.ts` — `FsSchema`, the file writer, plus `RESTORE_ORDER`. One `write<Object>` method per object kind, each prefixed by the `F_*_PREFIX` constants. `clean()` empties the output dir first. `writeTable` emits **one file per table** carrying its columns, its non-FK constraints, its owned sequences' `OWNED BY`, its indexes and its triggers; `writeForeignKeys` emits that table's FKs separately, since those must wait until every table exists. `outputFileSyncSafe` de-duplicates name collisions by appending `.v2`, `.v3`, ….
 - `src/pg-helpers.ts` — SQL/array helpers: `pgQuoteString`/`pgQuoteStrings` (escaping — every user-supplied value must go through these), `pgStringArray`, and `notExtensionOwned` (excludes objects an extension owns, which the extension recreates itself).
 - `src/fs-schema-helpers.ts` — SQL normalization for diffability: `normalizedSrc`, `unquoted`, `sortedAttributes` (deterministic column ordering), and `quoteIdent`/`quoteQualified`, which **every** emitted identifier must go through. Hand-quoting is how a mixed-case name silently folds and a name containing a quote character escapes its own identifier.
@@ -101,4 +148,5 @@ Flow: **collect** (read catalog) → **write** (emit files) — orchestrated by 
 - Adding a new object kind that gets **its own file** means four coordinated edits: a `collect*` in `src/pg-objects/`, a `write*` + `F_*_PREFIX` in `fs-schema.ts`, that prefix placed in `RESTORE_ORDER`, and a line in `dumpSchema`'s `Promise.all`. A prefix missing from `RESTORE_ORDER` sorts last, which usually still works but only by luck.
 - Adding one that belongs **to a table** (like indexes, triggers or non-FK constraints) instead means collecting it, grouping it by `schema.table` in `dumpSchema`, and emitting it from `writeTable` in a sorted order.
 - Every collector must honour the scope. A collector that ignores it silently widens a scoped dump back out to the whole database.
+- **Dependency vulnerabilities: read [pnpm-workspace.yaml](pnpm-workspace.yaml) before acting on a Dependabot alert.** Its `overrides` block is the carve-out list for transitive vulnerabilities no in-range refresh can reach, and it carries the policy in comments: prefer bumping the parent over adding an entry, every entry must cite its GHSA, and an entry is deleted once the parent ships the fix. An override that forces a version its parent never declared is a standing compatibility risk, so adding one is the last resort, not the first move.
 - Commit messages must be Conventional Commits — releases are derived from them. See [Releases](#releases--conventional-commits-are-mandatory) and [docs/release-please.md](docs/release-please.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Commit message _format_ is a separate, equally hard requirement, and is covered 
 - `pnpm test` — vitest, both projects (`unit` + `e2e`). `prepublishOnly` runs `build` → `eslint` → `test`.
 - `npm run eslint` — lint `./src` (`--ext=ts,tsx`).
 - `pnpm test:unit` — pure helper tests, no database needed. `pnpm test:e2e` — needs Docker.
-- `pnpm test:coverage` — what CI actually runs. [vitest.config.ts](vitest.config.ts) gates coverage at **90%** lines/statements/functions across `src` as a whole (`perFile: false`, `src/bin.ts` excluded), so a change that adds an untested branch passes `pnpm test` locally and still fails CI. Run this before pushing.
+- `pnpm test:coverage` — what CI actually runs. [vitest.config.ts](vitest.config.ts) gates coverage at **90%** lines/statements/functions. The gate is on the aggregate across `src` (`perFile: false`, `src/bin.ts` excluded, no branch threshold), so it is a floor against erosion, not a per-change standard — a small untested addition can slip under it on the totals. Run this before pushing; `pnpm test` alone will not tell you.
 - Run a single test: `pnpm exec vitest run tests/e2e/dump-db.test.ts` (add `-t "<name>"` to filter).
 - `npm start` — build then run the CLI against `dist/bin.js`.
 
@@ -53,17 +53,20 @@ CLI usage: `pg-schema-dump --url postgres://user:pass@host/db --out ./dir`. With
 
 Work on a branch and merge through a PR. **Never commit directly to `main`.** This is not merely
 convention: `main` has no branch protection ([docs/release-please.md](docs/release-please.md) §3),
-so a direct push is technically possible — and it bypasses the `PR Title` check, the only thing
-validating the commit subject that release-please parses. The change then lands on `main` and is
-never released.
+so a direct push is technically possible — and it is the one path that reaches `main` with the
+subject unchecked. The release workflow still runs, so a direct push with a conventional subject
+does release normally; the risk is the other case, where a non-conventional subject that the `PR
+Title` check would have rejected lands instead, and release-please silently parses nothing from it.
 
-Two existing rules apply to the branch name, the PR title and the PR body alike:
+Two existing rules govern a PR here:
 
-- **No tracker reference**, anywhere, not even in a footer — see [No tracker references](#no-tracker-references).
-- **The PR title must be a Conventional Commit**, because squash is the only merge method and the
-  title becomes the commit subject verbatim — see [Releases](#releases--conventional-commits-are-mandatory).
-  Pick the type from what the change actually ships: a PR that adds to the public API is a `feat:`
-  even when most of its diff is prose.
+- **No tracker reference** in the branch name, PR title, or PR body — anywhere, not even in a
+  footer. See [No tracker references](#no-tracker-references).
+- **The PR title specifically must be a Conventional Commit**, because squash is the only merge
+  method and the title becomes the commit subject verbatim — see
+  [Releases](#releases--conventional-commits-are-mandatory). This constrains the title only; branch
+  names and PR bodies are free-form (subject to the rule above). Pick the type from what the change
+  actually ships: a PR that adds to the public API is a `feat:` even when most of its diff is prose.
 
 ### Documentation is part of the change, not a follow-up
 
@@ -75,7 +78,7 @@ already produced stale docs here:
   where callers could not see or name what the function gave back.
 - **A change to the release process or a workflow updates [docs/release-please.md](docs/release-please.md).**
   It is declared the source of truth for that topic, so nothing else contradicts it when it drifts;
-  it went two releases still describing the repo as having never cut an automated one.
+  it went a whole release cycle still describing the repo as having never cut an automated one.
 
 Also update this file when a change alters the architecture, the commands, or a convention
 described above.
@@ -115,7 +118,7 @@ that pin raised first.
 Flow: **collect** (read catalog) → **write** (emit files) — orchestrated by `PgClient.dumpSchema`.
 
 - `src/index.ts` — the entire public surface: the `PgClient` class and the `DumpOmissions` type it returns. Nothing else is re-exported, so anything a consumer needs to name must be added here deliberately.
-- `src/bin.ts` — the CLI entrypoint (`#!/usr/bin/env node`), and the only place scope arrives from a user. yargs defines `--url` (required), `--out`, `--scope-file` and the repeatable `--include-schema` / `--include-table` / `--include-function`; a manifest read by `loadScopeFile` is combined with those flags by `mergeScope`, the result goes through `validateScope`, and only then is `PgClient` constructed. The `--out` default resolves `current_database()` over a throwaway `pg.Client` first. Excluded from coverage, so logic worth testing belongs in a module it calls rather than here.
+- `src/bin.ts` — the CLI entrypoint (`#!/usr/bin/env node`); one of the two ways a scope arrives from outside, the other being the `scope` constructor option a library caller passes. yargs defines `--url` (required), `--out`, `--scope-file` and the repeatable `--include-schema` / `--include-table` / `--include-function`; a manifest read by `loadScopeFile` is combined with those flags by `mergeScope`, the result goes through `validateScope`, and only then is `PgClient` constructed. The `--out` default resolves `current_database()` over a throwaway `pg.Client` first. Excluded from coverage, so logic worth testing belongs in a module it calls rather than here.
 - `src/pg-client.ts` — `PgClient`. Holds connection config (parses a URL via `pg-connection-string`, or takes a `pg.ClientConfig`). Key design point: **connections are not kept open** — `query()` does `connect → query → end` each call (see commit `v1.1.0`). `dumpSchema` is the exception: it opens one connection, runs all collectors in a single `Promise.all`, then ends. It returns a `DumpOmissions` (`{ droppedForeignKeys, excludedViews }`) as well as logging it, because `logger: null` is supported and a scope that silently dropped an FK is the costliest failure to find late — a new kind of omission belongs in that return value, not only in a log line. Also provides DB lifecycle helpers used by tests and consumers (`ensureEmptyDb`, `switchDatabase`, `dropDatabase`, `truncateTables`, `restoreSchema`).
 - `src/pg-objects/*.ts` — one `collect<Object>(client, opts)` per object kind (extensions, types, functions, indexes, sequences, tables, triggers, views, constraints). Each runs a raw `pg_catalog` query and returns plain rows. `tables.ts` builds each column via nested `jsonb_build_object` in SQL. Constraint and index DDL is **not** hand-assembled — `pg_get_constraintdef` / `pg_get_indexdef` produce it. To add/change what's captured, edit the relevant collector's query.
 - `src/pg-objects/scope-sql.ts` — **all shared scope SQL. Nothing here may be restated in a collector.** Two rounds of review found bugs that were exactly a collector hand-rolling its own variant of one of these and getting it subtly wrong, so if a collector needs one of these questions answered, it calls the function:
@@ -139,7 +142,7 @@ Flow: **collect** (read catalog) → **write** (emit files) — orchestrated by 
    - **every table before any foreign key**, so FK cycles between tables restore cleanly;
    - indexes and triggers inline in the table file, which is safe precisely because functions already exist by then.
 
-   `restoreSchema` still requeues a failing file (chained views can need a second pass) and gives up once a full cycle makes no progress, reporting **every** unapplied file with its own error. It deliberately does not wrap the restore in a transaction — a failed statement would poison it, which is incompatible with requeueing.
+   `restoreSchema` still requeues a failing file — as many times as the queue comes round, not once; a chain of views can need several — and gives up only once a full cycle makes no progress, reporting **every** unapplied file with its own error. It deliberately does not wrap the restore in a transaction — a failed statement would poison it, which is incompatible with requeueing.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -143,12 +143,15 @@ new PgClient(config, {
 
 ### What a dump reports
 
-`dumpSchema` resolves to a `DumpOmissions` describing what the scope left out. Both lists are
-empty for an unscoped dump.
+`dumpSchema` resolves to a `DumpOmissions` describing what the dump left out.
 
 ```ts
 import { PgClient } from '@pureprofile/pg-schema-dump';
 import type { DumpOmissions } from '@pureprofile/pg-schema-dump';
+
+const client = new PgClient('postgres://user:pass@localhost/mydb', {
+  scope: { includeTables: ['public.orders'] },
+});
 
 const omissions: DumpOmissions = await client.dumpSchema({ out: './schema/mydb' });
 
@@ -157,15 +160,24 @@ for (const fk of omissions.droppedForeignKeys) {
   console.warn(`dropped ${fk.schema}.${fk.table}.${fk.name} -> ${fk.target}`);
 }
 for (const view of omissions.excludedViews) {
-  // { view, cause } — `cause` is the out-of-scope object the view reads
+  // { view, cause } — `cause` is a 'schema.name' the view reads that the dump does not contain
   console.warn(`excluded ${view.view} (needs ${view.cause})`);
 }
 ```
 
-These are returned as well as logged on purpose. `logger: null` is a supported option, and a
-scoped dump that quietly drops a foreign key or a view is the failure that costs the most to
-discover later — so a caller doing its own reporting gets a programmatic record rather than
-having to scrape the log.
+Two caveats on reading these:
+
+- **`cause` is the missing dependency, not necessarily the root of the problem.** Excluding one
+  view excludes whatever is built on top of it, and a view dropped that way reports the excluded
+  view it reads — so following a chain may take more than one step.
+- **`droppedForeignKeys` is always empty for an unscoped dump**, but `excludedViews` need not be:
+  a view reading a relation in a `skipSchemas` schema is excluded on the same grounds, scope or no
+  scope. Note also that the warning log is only written when a scope is active, so an unscoped dump
+  reports such a view here and nowhere else.
+
+These are returned as well as logged on purpose. `logger: null` is a supported option, and a dump
+that quietly drops a foreign key or a view is the failure that costs the most to discover later —
+so a caller doing its own reporting gets a programmatic record rather than having to scrape the log.
 
 ### Restoring a dump
 
@@ -277,9 +289,10 @@ One container is started for the whole e2e project, and the project runs single-
 file parallelism, so e2e tests share a single PostgreSQL instance rather than getting one each.
 
 **Coverage is gated.** [vitest.config.ts](vitest.config.ts) sets a 90% threshold on lines,
-statements and functions, measured across `src` as a whole (`perFile: false`, with `src/bin.ts`
-excluded). CI runs `pnpm test:coverage`, so new code without tests fails the build there — run it
-locally before pushing rather than finding out in CI.
+statements and functions, and CI runs `pnpm test:coverage`, so falling below it fails the build.
+The threshold is on the aggregate, not per file (`perFile: false`, with `src/bin.ts` excluded and
+no branch threshold), so a small untested addition can still pass on the totals — treat 90% as the
+floor it is, not as the standard for a change. Run it locally before pushing.
 
 ### Git hooks
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pg-schema-dump --url <connection-string> [--out <dir>] [scope options]
 
 When `--out` is omitted, output goes to `pg-schema-dump/<NODE_ENV>/<dbName>` (where `NODE_ENV` defaults to `development` and `dbName` is read from the connection).
 
-With no scope options the whole database is dumped, exactly as before.
+With no scope options the whole database is dumped.
 
 ### Examples
 
@@ -141,15 +141,41 @@ new PgClient(config, {
 });
 ```
 
+### What a dump reports
+
+`dumpSchema` resolves to a `DumpOmissions` describing what the scope left out. Both lists are
+empty for an unscoped dump.
+
+```ts
+import { PgClient } from '@pureprofile/pg-schema-dump';
+import type { DumpOmissions } from '@pureprofile/pg-schema-dump';
+
+const omissions: DumpOmissions = await client.dumpSchema({ out: './schema/mydb' });
+
+for (const fk of omissions.droppedForeignKeys) {
+  // { schema, table, name, target } — `target` is the out-of-scope 'schema.table' it pointed at
+  console.warn(`dropped ${fk.schema}.${fk.table}.${fk.name} -> ${fk.target}`);
+}
+for (const view of omissions.excludedViews) {
+  // { view, cause } — `cause` is the out-of-scope object the view reads
+  console.warn(`excluded ${view.view} (needs ${view.cause})`);
+}
+```
+
+These are returned as well as logged on purpose. `logger: null` is a supported option, and a
+scoped dump that quietly drops a foreign key or a view is the failure that costs the most to
+discover later — so a caller doing its own reporting gets a programmatic record rather than
+having to scrape the log.
+
 ### Restoring a dump
 
-`restoreSchema` reads a dump directory and replays it into the connected database.
+`restoreSchema` reads a dump directory and replays it into the connected database. It opens its own
+connection and closes it again, on success and on failure alike, so it needs no surrounding
+`connect()` / `end()`:
 
 ```ts
 const client = new PgClient('postgres://user:pass@localhost/fresh_db');
-await client.connect();
 await client.restoreSchema({ src: './schema/mydb' });
-await client.end();
 ```
 
 Files are applied in an order where every dependency is satisfied by an earlier file, so a dump replays in a single pass:
@@ -170,7 +196,7 @@ Two consequences worth knowing:
 - **Functions are restored before tables**, under `check_function_bodies = off`, so a function body may reference a table that does not exist yet. This is what makes it safe to merge triggers and expression indexes into table files.
 - **Every table is created before any foreign key is added**, so foreign key _cycles_ between tables restore without special handling.
 
-A file that fails is requeued once behind the others — enough for chained views — and the restore gives up when a full cycle passes with nothing succeeding. The error then names **every** file left unapplied with its own cause:
+A file that fails is not fatal: it goes to the back of the queue and is tried again later, as many times as the queue comes round — enough for chained views, where a view selects from another view that has not been created yet. The restore gives up only once a full lap of the queue completes with nothing applied, since the database is then unchanged and another lap would repeat the same failures. The error names **every** file left unapplied with its own cause:
 
 ```
 restoreSchema: 2 file(s) could not be applied:
@@ -188,8 +214,11 @@ await client.databaseExists('mydb_test');
 await client.createDatabase('mydb_test');
 await client.dropDatabase('mydb_test');
 await client.switchDatabase('other_db');
-await client.truncateTables('mydb_test'); // TRUNCATE ... CASCADE all non-skipped tables
+await client.truncateTables('mydb_test'); // switch to it, then TRUNCATE ... CASCADE every non-skipped table
 ```
+
+Note `truncateTables` switches the client to `db` first and leaves it there, the same way
+`ensureEmptyDb` does — it is not a read-only operation against some other database.
 
 ## Output structure
 
@@ -212,7 +241,10 @@ Constraint definitions come from `pg_get_constraintdef`, so composite primary ke
 
 `nextval(...)` column defaults are emitted verbatim rather than collapsed to `serial`/`bigserial`. The shorthand made Postgres auto-create a second sequence that collided with the dumped one, and it only ever matched tables in the search path, since sequence names are schema-qualified elsewhere.
 
-### Known gaps
+## Limitations
+
+Worth reading before adopting the tool — a schema using any of the following will dump or restore
+incompletely.
 
 Not currently collected: materialized views, partitioned tables (`relkind = 'p'`), `GENERATED ... AS IDENTITY` columns, domain/composite/range types (only enums), and row data — a dump is schema-only, so fixtures need their own seed script.
 
@@ -224,24 +256,30 @@ One restore-order shape is not solvable by the bucket rank, and will fail rather
 
 ## Development
 
-This project uses **pnpm** and requires **Node** (see [.nvmrc](.nvmrc)).
+This project uses **pnpm** and requires **Node 24** (see [.nvmrc](.nvmrc)).
 
 ```bash
 pnpm install
 pnpm build          # rimraf ./dist && tsc
 pnpm eslint         # lint ./src
-pnpm test:unit      # vitest unit tests (no database required)
-pnpm test:coverage  # full suite (unit + e2e) with coverage over ./src
+pnpm test:unit      # unit project only (no database required)
+pnpm test:e2e       # e2e project only (requires Docker)
+pnpm test           # both projects
+pnpm test:coverage  # both projects, with coverage over ./src
 ```
 
 ### Tests
 
 - **Unit** tests (`tests/unit/`) are pure and need no database.
-- **E2E** tests (`tests/e2e/`) use [Testcontainers](https://testcontainers.com/) to spin up an ephemeral PostgreSQL container, so **Docker must be running** locally. In CI, `ubuntu-latest` ships Docker, so no extra setup is needed. To run e2e against an existing database instead of a container, set `TEST_DB_HOST` (and optionally `TEST_DB_PORT` / `TEST_DB_USER` / `TEST_DB_PASSWORD`).
+- **E2E** tests (`tests/e2e/`) use [Testcontainers](https://testcontainers.com/) to spin up an ephemeral `postgres:16-alpine` container, so **Docker must be running** locally. In CI, `ubuntu-latest` ships Docker, so no extra setup is needed. To run e2e against an existing database instead of a container, set `TEST_DB_HOST` (and optionally `TEST_DB_PORT` / `TEST_DB_USER` / `TEST_DB_PASSWORD`).
 
-```bash
-pnpm test:e2e       # e2e project only (requires Docker)
-```
+One container is started for the whole e2e project, and the project runs single-forked and without
+file parallelism, so e2e tests share a single PostgreSQL instance rather than getting one each.
+
+**Coverage is gated.** [vitest.config.ts](vitest.config.ts) sets a 90% threshold on lines,
+statements and functions, measured across `src` as a whole (`perFile: false`, with `src/bin.ts`
+excluded). CI runs `pnpm test:coverage`, so new code without tests fails the build there — run it
+locally before pushing rather than finding out in CI.
 
 ### Git hooks
 

--- a/docs/release-please.md
+++ b/docs/release-please.md
@@ -238,9 +238,10 @@ mis-derive the starting version. The manifest makes it explicit and deterministi
 release-please rewrites this file in each release PR.
 
 **`CHANGELOG.md`** — grouped by the changelog sections in the table above, newest
-version first, with links to each commit and PR. It is a build artifact of the
-commit history, not a document anyone writes; release-please created it with the
-`v2.0.0` release and prepends a section to it on every release since.
+version first, each entry linking back to the pull request or commit it came from.
+It is a build artifact of the commit history, not a document anyone writes;
+release-please created it with the `v2.0.0` release and prepends a section to it on
+every release since.
 
 ## 6. Files release-please owns — never hand-edit
 
@@ -348,11 +349,13 @@ version. Do not delete or move the tag, and do not expect a re-run to fix it (se
 - **Only one release run at a time.** `concurrency: release_please` (no
   `cancel-in-progress`) serialises runs so two pushes cannot race on the tag or the
   release PR.
-- **A release PR is not immediate.** Nothing appears until a releasing commit
-  lands, so a run of `chore`/`test`/`docs`/`ci` merges leaves `main` with no open
-  release PR and no error — that is the expected state, not a broken pipeline. The
-  PR appears when a `fix:`/`feat:`/`revert:`/breaking commit lands, or immediately
-  if you use a `Release-As:` footer per
+- **A release PR is not immediate.** Nothing _opens_ one until a releasing commit
+  lands, so a run of `chore`/`test`/`docs`/`ci` merges with no release PR already
+  open leaves `main` with none, and no error — that is the expected state, not a
+  broken pipeline. (If a release PR is already open, those merges do not close it;
+  they are folded into it as part of the range, without changing the version it
+  proposes.) The PR opens when a `fix:`/`feat:`/`revert:`/breaking commit lands, or
+  immediately if you use a `Release-As:` footer per
   [How to force a release](#8-how-to-force-a-release).
 - **Releases only ever come from `main`.** Both jobs carry
   `if: github.ref == 'refs/heads/main'`, so a `workflow_dispatch` aimed at a feature

--- a/docs/release-please.md
+++ b/docs/release-please.md
@@ -25,9 +25,9 @@ sits there unreleased. That is the one failure mode to internalise.
 Releases up to `v1.1.0` were a manual ritual: hand-edit `version` in
 `package.json`, commit it as `v1.1.0: rewrite to not keep open connections`, push
 a tag by hand, then run `npm publish` from a laptop. The results show the cost —
-there is no `CHANGELOG.md` in the repo's history, and none of `v1.0.0` … `v1.1.0`
-has a GitHub Release, so there is no published record of what changed in any
-version.
+the repo had no changelog at all until automation generated one, and none of
+`v1.0.0` … `v1.1.0` has a GitHub Release, so for those versions there is still no
+published record of what changed.
 
 release-please replaces all of that with one input (the commit message) and one
 decision point (merging the release PR).
@@ -222,21 +222,25 @@ the npm name, used in the changelog and release titles. `include-component-in-ta
 is **`false`**, which matters: manifest mode defaults it to `true`, which would
 produce `pg-schema-dump-v1.2.0` tags instead of the `v1.2.0` format the repo has
 used since `v1.0.0`. `last-release-sha` is pinned to
-`33832d8e56c042f8bc08b3ee9d3355a59e7eaf33`, the commit tagged `v1.1.0`: it stops
-the commit scan there so the first changelog covers only post-`v1.1.0` work
-instead of reaching back over the entire history.
+`33832d8e56c042f8bc08b3ee9d3355a59e7eaf33`, the commit tagged `v1.1.0`: it bounded
+the scan for the **first** automated release (`v2.0.0`) so its changelog covered
+only post-`v1.1.0` work instead of reaching back over the entire history. It is
+inert now — every release since keys off the release tags release-please created
+itself — but removing it would let a future full-history scan reach back past
+`v1.1.0` again, so it stays.
 
 **[`.release-please-manifest.json`](../.release-please-manifest.json)** — the
-recorded current version, `1.1.0`, matching `package.json`. Its presence is what
+recorded current version, `2.0.0`, matching `package.json`. Its presence is what
 puts release-please in **manifest mode**, and that is deliberate: in the simpler
 `release-type` input mode, release-please discovers the last version from GitHub
 _Releases_, and this repo's pre-automation tags have none — so it could
 mis-derive the starting version. The manifest makes it explicit and deterministic.
 release-please rewrites this file in each release PR.
 
-**`CHANGELOG.md`** (generated on the first release) — grouped by the changelog
-sections in the table above, newest version first, with links to each commit and
-PR. It is a build artifact of the commit history, not a document anyone writes.
+**`CHANGELOG.md`** — grouped by the changelog sections in the table above, newest
+version first, with links to each commit and PR. It is a build artifact of the
+commit history, not a document anyone writes; release-please created it with the
+`v2.0.0` release and prepends a section to it on every release since.
 
 ## 6. Files release-please owns — never hand-edit
 
@@ -279,9 +283,12 @@ Publishing uses **npm [trusted publishing](https://docs.npmjs.com/trusted-publis
   [`.nvmrc`](../.nvmrc) (`24`), and current 24.x releases bundle npm 11.17.0, so
   this is satisfied — but note Node 24.0.0 itself shipped npm 11.3.0, below the
   floor. See [Troubleshooting](#10-troubleshooting) if it ever regresses.
-- **`actions/setup-node` must be v7 or newer.** v6 exports a dummy
-  `NODE_AUTH_TOKEN` whenever `registry-url` is set, which makes npm attempt token
-  auth and fail instead of using OIDC.
+- **`actions/setup-node` must be v7 or newer _in the `publish` job_.** v6 exports a
+  dummy `NODE_AUTH_TOKEN` whenever `registry-url` is set, which makes npm attempt
+  token auth and fail instead of using OIDC. The rule is specific to that trigger:
+  [`ci.yml`](../.github/workflows/ci.yml) sets no `registry-url` and never
+  publishes, so its `setup-node` version is unconstrained by this — do not "fix"
+  it to match.
 
 **The `prepublishOnly` gate.** `npm publish` runs the `prepublishOnly` script from
 [`package.json`](../package.json) — currently `build` → `eslint` → `test`, where
@@ -305,7 +312,7 @@ version. Do not delete or move the tag, and do not expect a re-run to fix it (se
   ```
   chore: refresh dependency overrides
 
-  Release-As: 1.1.1
+  Release-As: 2.0.1
   ```
 
   A PR title cannot carry a footer, so put it in a **commit message on the branch**
@@ -341,10 +348,11 @@ version. Do not delete or move the tag, and do not expect a re-run to fix it (se
 - **Only one release run at a time.** `concurrency: release_please` (no
   `cancel-in-progress`) serialises runs so two pushes cannot race on the tag or the
   release PR.
-- **The first release PR is not immediate.** The commits already on `main` after
-  `v1.1.0` are all `chore`/`test`/`docs`, so nothing releasable exists yet. The
-  first release PR appears when a `fix:`/`feat:`/`revert:`/breaking commit lands —
-  or immediately, if you use a `Release-As:` footer per
+- **A release PR is not immediate.** Nothing appears until a releasing commit
+  lands, so a run of `chore`/`test`/`docs`/`ci` merges leaves `main` with no open
+  release PR and no error — that is the expected state, not a broken pipeline. The
+  PR appears when a `fix:`/`feat:`/`revert:`/breaking commit lands, or immediately
+  if you use a `Release-As:` footer per
   [How to force a release](#8-how-to-force-a-release).
 - **Releases only ever come from `main`.** Both jobs carry
   `if: github.ref == 'refs/heads/main'`, so a `workflow_dispatch` aimed at a feature

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "packageManager": "pnpm@11.5.0",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "pg-schema-dump": "./dist/bin.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { PgClient } from './pg-client';
+export type { DumpOmissions } from './pg-client';

--- a/src/pg-client.ts
+++ b/src/pg-client.ts
@@ -20,12 +20,20 @@ import { validateScope } from './scope-file';
 const DEFAULT_SCHEMAS_TO_SKIP: string[] = ['pg_catalog', 'information_schema'];
 const DEFAULT_FUNCTIONS_TO_SKIP: string[] = [];
 
-/** What a scope excluded from a dump. Both lists are empty for an unscoped dump. */
+/** What the dump left out. */
 export interface DumpOmissions {
-  /** Foreign keys omitted because the table they reference is out of scope. */
+  /**
+   * Foreign keys omitted because the table they reference is out of scope.
+   * Always empty for an unscoped dump - with no scope there is no out of scope.
+   */
   droppedForeignKeys: CollectedConstraints['droppedForeignKeys'];
 
-  /** Views omitted because something they read is out of scope. */
+  /**
+   * Views omitted because something they read is not in the dump. Usually a scope
+   * decision, but *not* only one: a view reading a relation in a `skipSchemas`
+   * schema is excluded on the same grounds, so this can be non-empty for an
+   * unscoped dump too.
+   */
   excludedViews: CollectedViews['excluded'];
 }
 

--- a/src/pg-objects/triggers.ts
+++ b/src/pg-objects/triggers.ts
@@ -33,7 +33,7 @@ export async function collectTriggers(
       -- their table's file, so a trigger on anything else - an INSTEAD OF trigger on a
       -- view, a trigger on a partitioned parent - has no file to be written into and
       -- was silently discarded after being collected. Excluding it here makes that a
-      -- stated limitation instead of a quiet loss. See README's Known gaps.
+      -- stated limitation instead of a quiet loss. See README's Limitations.
       AND c.relkind = 'r'
       AND ${notExtensionOwned('pg_class', 'c.oid')}
       -- An extension may own a trigger on an ordinary table and recreate it itself,


### PR DESCRIPTION
## Why

Two things had drifted since the docs were written.

**`docs/release-please.md` predates the first automated release** and still described that state — manifest version `1.1.0` (it is `2.0.0`), `CHANGELOG.md` as a file "generated on the first release" (it exists), and a bullet explaining why no release PR had appeared yet. Anyone using its troubleshooting table was comparing against the wrong baseline.

**`dumpSchema` has returned a `DumpOmissions` since v2.0.0** — the foreign keys and views a scope dropped — and nothing said so. Worse, `src/index.ts` re-exported only `PgClient`, so the type could not be named. A whole major version where callers could neither see nor type what the function handed back.

## What changed

**Code (one line):** `export type { DumpOmissions }` from `src/index.ts`. Type-only, no runtime surface — hence the `feat:` type, since it does add to the public API.

**Corrected against the code:**

| Doc | Said | Actually |
| --- | --- | --- |
| README | a failing restore file "is requeued once" | requeued repeatedly; gives up after a full lap with nothing applied |
| README | restore example wraps `restoreSchema` in `connect()`/`end()` | it manages its own connection, on success and failure alike |
| README | `truncateTables` listed as a plain truncate | it switches the client to that database first and leaves it there |
| release-please §5 | manifest is `1.1.0`; CHANGELOG "generated on the first release" | `2.0.0`; the changelog exists |
| release-please §2, §9 | repo has no changelog; no release PR has appeared yet | both obsolete — v2.0.0 shipped |

**Facts added that were only discoverable by failing:** the 90% coverage gate CI enforces via `pnpm test:coverage`, the single shared `postgres:16-alpine` e2e container (tests must not assume an isolated server), the `pnpm-workspace.yaml` dependency-override policy, and `src/bin.ts` — the CLI entrypoint, previously absent from the architecture list entirely.

**Structure:** the README's known gaps were a subsection of *Output structure*; they are now a top-level **Limitations** section, since that is what a reader evaluating the tool needs. Content unchanged and re-verified against the `relkind` filters. `docs/release-please.md` section numbering is deliberately left alone — it self-links by numbered anchor.

**Two new AGENTS.md rules**, both prompted by this pass:

- Every change lands through a PR, never a direct push to `main`. `main` has no branch protection, so a direct push bypasses the `PR Title` check — the only thing validating the subject release-please parses — and the change ships unreleased.
- Documentation invalidated by a change is updated in the same PR. Scoped to hand-written docs only, with an explicit carve-out for the release-please-owned files.

## Verification

`pnpm build`, `pnpm eslint` (0 errors; 2 warnings pre-existing in untouched files), `pnpm test:unit` (65 passed), `prettier --check` clean. Every internal markdown anchor still resolves — including a code comment in `src/pg-objects/triggers.ts` that pointed at the renamed README heading. Full e2e runs here in CI.

_Generated by [Claude Code](https://claude.ai/code)_
